### PR TITLE
docs: harden baseline audit and worklist for compcf

### DIFF
--- a/docs/repository-baseline-audit.md
+++ b/docs/repository-baseline-audit.md
@@ -1,174 +1,216 @@
-# Repository Baseline Audit — CompCF
+# CompCF Repository Baseline Audit
 
 ## Executive summary
-CompCF currently has a **working UI shell** and a **light Supabase-connected MVP skeleton** centered on: published events listing, auth entry points, and role-gated dashboards for athlete/organizer/admin. The codebase is an early-stage monolithic Next.js App Router project without backend API routes, without local database schema/migrations, and without CI configuration in-repo.
+CompCF already provides a usable MVP shell for CrossFit events: public event listing, auth entry, and role-gated dashboards for organizer, athlete, and admin. The core gap is not UI polish; it is **domain completeness and operational reliability** for CrossFit competition execution.
 
-This baseline is useful for iterative delivery, but several core CrossFit-competition capabilities described in product intent are either partial or not implemented yet (divisions/categories management UI, registration flow creation, qualification, scoring, leaderboard, heats/schedule, judge tooling).
-
-> Scope note: this audit is based on repository-tracked files and targeted code reads of key modules; it groups repetitive patterns and does not claim exhaustive semantic verification of every JSX branch.
+This audit keeps technical findings from the previous version and adds explicit domain modeling so implementation can proceed in a controlled order.
 
 ---
 
-## Repository map
+## Repository map (what is currently present)
+- `app/`: Next.js App Router pages (`/`, `/events`, `/login`, `/signup`, `/organizer`, `/athlete`, `/admin`).
+- `components/`: marketing shell + event card UI.
+- `lib/supabaseClient.ts`: shared Supabase client using public env vars.
+- Root config: Next.js, TypeScript, ESLint, Tailwind.
+- Docs: default README + product narrative README variant.
 
-### Top-level tracked areas
-- `app/` — Next.js App Router pages and global layout/styles.
-- `components/` — shared UI building blocks (`marketing`, `events`, `UI`).
-- `lib/` — shared utility (`supabaseClient`).
-- `public/` — static SVG assets.
-- Root configs: `package.json`, `tsconfig.json`, `next.config.ts`, `eslint.config.mjs`, lockfile.
-- Root docs currently include a generic `README.md` and a product-vision-heavy `Readme.md`.
-
-### Route/page inventory (implemented)
-- `/` marketing landing page.
-- `/events` published events listing with category active pricing lookup.
-- `/login` email/password auth UI.
-- `/signup` email/password signup UI.
-- `/athlete` role-gated athlete dashboard.
-- `/organizer` role-gated organizer dashboard.
-- `/admin` role-gated admin dashboard.
+Not present in repo:
+- SQL migrations/schema history.
+- RLS policy definitions.
+- CI pipelines.
+- automated test suites.
 
 ---
 
-## Current modules identified
+## Current modules and maturity
 
-### 1) Marketing & navigation module
-- Shared `SiteHeader` + `SiteFooter` used on pages.
-- Landing page communicates product promise and roles.
-- Visual style: Tailwind utility-driven, dark gradient branding.
+### Implemented
+- Branded public pages and navigation.
+- Public events page querying `events`, `event_categories`, `category_pricing_tiers`.
+- Supabase email/password login and signup.
+- Role-gated pages for organizer, athlete, admin.
+- Organizer can create and publish basic events.
 
-### 2) Authentication entry module
-- Login/signup implemented as client pages using Supabase auth methods:
-  - `signInWithPassword`
-  - `signUp`
-- Redirect behavior on login currently points to `/athlete` from generic login page (no role-aware routing yet).
+### Partial
+- Registration lifecycle: visibility exists (`registration_details`) but complete creation/validation/payment flow is not modeled in-app.
+- Authorization: role checks mostly live at UI level; policy layer is not versioned in repo.
+- Product/domain docs: intent exists, but domain rules are not yet formalized enough for consistent implementation.
 
-### 3) Role-gated dashboards module (client side)
-- Athlete dashboard:
-  - loads profile by current auth user
-  - enforces `profile.role === 'athlete'`
-  - reads published events
-  - reads `registration_details`, then filters client-side by athlete id
-- Organizer dashboard:
-  - enforces `profile.role === 'organizer'`
-  - loads events list
-  - creates events (minimal fields)
-  - publishes events by status update
-  - reads `registration_details` then filters by own event ids
-- Admin dashboard:
-  - enforces `profile.role === 'admin'`
-  - loads profiles/events/registration_details summaries
-
-### 4) Public events module
-- Server component queries `events` and `category_pricing_tiers` from Supabase.
-- Computes active pricing tier by date window + sort order.
-- Renders event cards with category count and active price.
-
-### 5) Shared data access module
-- Single exported Supabase client in `lib/supabaseClient.ts` using public env vars.
-- No typed database schema bindings generated in-repo.
+### Missing (domain-critical)
+- Explicit staff and judge operating surfaces.
+- Competition execution objects (workouts, heats, lanes, score entry pipeline, leaderboard engine).
+- Qualification/cut progression.
+- Auditable score correction lifecycle.
 
 ---
 
-## Implemented vs partial vs scaffolded vs missing
+## Role model (CompCF domain baseline)
 
-## Implemented (observable in repo)
-- App Router project bootstrapped and runnable with Next.js + TypeScript + Tailwind.
-- Basic branded UX and multi-page navigation.
-- Supabase client configured and actively used in pages.
-- Email/password auth entry flows.
-- Role checks on athlete/organizer/admin dashboards.
-- Public events query + active pricing display logic.
-- Organizer ability to create/publish events (basic fields only).
+### 1) Organizer
+- **Purpose:** owns competition setup and publication.
+- **MVP permissions:** create/update/publish event; define divisions/categories; define pricing tiers; monitor registrations for own events.
+- **Post-MVP permissions:** configure phases/heats; assign staff/judges; approve score corrections; publish official results.
 
-## Partially implemented
-- **Registration domain**: dashboard visibility exists via `registration_details`, but no user-facing registration creation workflow in-app.
-- **Roles & authorization**: role checks are client-side in page logic; no visible server-side authorization layer in repo.
-- **Product docs**: product intent exists in `Readme.md`, but ops/dev docs are minimal and partially duplicated (`README.md` vs `Readme.md`).
-- **Data model visibility**: code references tables/views (`profiles`, `events`, `event_categories`, `category_pricing_tiers`, `registration_details`) but schema definitions are not versioned in this repo.
+### 2) Staff
+- **Purpose:** supports event operations under organizer authority.
+- **MVP permissions:** view assigned event operations data (check-in lists, registration status).
+- **Post-MVP permissions:** manage heat logistics, lane assignments, athlete check-in status, operational incident notes.
 
-## Scaffolded / placeholder
-- `next.config.ts` default placeholder config.
-- `README.md` default create-next-app content.
-- Some UI routes behave as MVP shell without complete domain actions.
+### 3) Judge
+- **Purpose:** captures performance data for assigned heats/workouts.
+- **MVP permissions:** none (role exists in model but no UI yet).
+- **Post-MVP permissions:** submit scores for assigned heat/workout, submit correction requests with reason, lock/unlock status per workflow policy.
 
-## Missing (for stated platform direction)
-- In-repo SQL migrations/schema, seed data, RLS policies, and Supabase config files.
-- Qualification workflows.
-- Live scoring engine and leaderboard computation/publishing.
-- Scheduling/heats/lanes management.
-- Judge workflow interfaces.
-- Payment/checkout (Stripe intentionally deferred, but no placeholder integration path documented).
-- API route layer / service layer for domain writes and secure orchestration.
-- Automated tests (unit/integration/e2e) and CI pipelines.
-- Deployment/IaC docs (Vercel env governance, preview/prod strategy).
+### 4) Individual athlete
+- **Purpose:** registers and competes as solo participant.
+- **MVP permissions:** create account, browse events, register for one category within rules, track own registration status.
+- **Post-MVP permissions:** submit qualification scores/media where applicable, view heat assignment and live leaderboard position.
 
----
+### 5) Team captain
+- **Purpose:** manages team composition and team registrations.
+- **MVP permissions:** none (role not yet implemented in UI).
+- **Post-MVP permissions:** create/manage team roster, register team category, confirm waivers/data for members.
 
-## Stack and architecture observations
-- **Stack coherence:** declared stack mostly aligns with reference (Next.js/TS/Tailwind/Supabase, GitHub). shadcn/ui is not present in tracked files yet.
-- **Architecture shape:** currently page-centric with direct Supabase calls from React components; simple and fast for MVP iteration, but risks coupling UI and data access.
-- **Module boundaries:** boundaries are coarse but understandable (`app/`, `components/`, `lib/`). No domain package segmentation yet.
-- **Frontend consistency:** design language is coherent and reused through shared header/footer and card patterns.
+### 6) Public user (spectator)
+- **Purpose:** follows competitions without account requirements.
+- **MVP permissions:** view published event pages and visible pricing/category info.
+- **Post-MVP permissions:** view live schedule, heat status, and leaderboard updates.
 
 ---
 
-## Supabase / schema observations
-- Supabase client exists and is used across core flows.
-- Environment variables required:
-  - `NEXT_PUBLIC_SUPABASE_URL`
-  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- Repository references multiple tables/views but does not include:
-  - migration history
-  - canonical schema SQL
-  - policy definitions
-  - generated type bindings
-- Because schema is externalized, repository-only review cannot fully validate data integrity assumptions or authorization safety.
+## Workflow baselines (concrete flows)
+
+### Organizer workflow
+1. Create event metadata (name/date/location/status draft).
+2. Define event divisions (e.g., RX, Scaled, Masters, Team).
+3. Define categories under each division (e.g., RX Men, RX Women, Team of 2).
+4. Configure pricing tiers per category (early/regular/late, validity windows, capacity constraints).
+5. Publish event.
+6. Monitor registrations and category fill rates.
+7. (Post-MVP) configure workouts, phases, heats, lanes.
+8. (Post-MVP) assign staff/judges and publish live competition artifacts.
+
+### Athlete workflow (individual)
+1. Sign up / log in.
+2. Browse published events.
+3. Select compatible division/category.
+4. Confirm active price tier and registration eligibility.
+5. Submit registration and receive status.
+6. (Post-MVP) submit qualification result if required.
+7. (Post-MVP) view heat assignment and final/ongoing leaderboard.
+
+### Judge workflow (post-MVP)
+1. Log in with judge role.
+2. Open assigned heat/workout queue.
+3. Enter score + tie-break value + notes for assigned lane/athlete/team.
+4. Submit score; status moves to pending validation/official according to policy.
+5. File correction with reason code when needed.
+6. Track correction acceptance/rejection outcome.
+
+### Spectator workflow
+1. Open published event page.
+2. View event structure (divisions/categories/pricing context).
+3. (Post-MVP) view schedule/phases/heats.
+4. (Post-MVP) follow live leaderboard and result updates.
 
 ---
 
-## Code quality observations
-- Positives:
-  - readable TypeScript
-  - consistent naming
-  - straightforward control flow
-  - reusable presentational components
-- Risks/debt:
-  - repeated auth/profile loading patterns across role pages (duplication)
-  - optimistic writes without robust error handling or user feedback in some dashboard actions
-  - client-side filtering of potentially broad datasets (`registration_details`) may not scale
-  - role enforcement appears primarily UI-level in this repo snapshot
-  - mixed documentation quality and duplicate readme naming can confuse contributors
+## Data model baseline (implementation-oriented)
+
+## Core entities
+- `profiles`: identity + role anchor for authenticated users.
+- `events`: competition container.
+- `event_divisions`: standardized competitive buckets (RX/Scaled/Masters/Team etc.).
+- `event_categories`: registerable categories within a division.
+- `category_pricing_tiers`: time/capacity-based pricing windows for a category.
+- `registrations`: source of truth for athlete/team registration state.
+- Future competition entities:
+  - `workouts`
+  - `event_phases`
+  - `heats`
+  - `lanes`
+  - `scores`
+  - `leaderboards`
+
+## Relationships (minimum expected)
+- `events` 1→N `event_divisions`
+- `event_divisions` 1→N `event_categories`
+- `event_categories` 1→N `category_pricing_tiers`
+- `event_categories` 1→N `registrations`
+- `events` 1→N `workouts` (or by phase)
+- `event_phases` 1→N `heats`
+- `heats` 1→N `lanes`
+- `scores` belongs to (`workout`, `registration`, optionally `heat/lane`)
+- `leaderboards` derived from `scores` (not manually edited)
+
+## Key constraints
+- Category must belong to one division and one event.
+- Registration must reference one event + one category + one competitor identity (athlete or team).
+- One competitor cannot hold duplicate active registrations in same category/event.
+- Pricing tier validity windows cannot overlap ambiguously for same category unless explicit priority exists.
+- Score changes must be auditable (actor, timestamp, reason).
+
+## Source-of-truth expectations
+- Supabase schema + policies must become versioned in-repo.
+- Repository documentation must map each domain object to concrete DB tables/views.
+- Derived artifacts (leaderboards) must be recomputable from canonical score records.
 
 ---
 
-## Product alignment observations
-- Strong alignment with core promise for:
-  - event publication visibility
-  - role-separated surfaces
-  - category/pricing communication on public events page
-- Limited alignment today for:
-  - end-to-end registration lifecycle (creation/payment/validation)
-  - operational competition execution (heats/scoring/leaderboard)
-  - judge-centered workflows
+## CrossFit-specific business model requirements (target state)
 
-Net: repository is a credible **foundation prototype**, not yet a feature-complete competition platform.
+### WOD types
+- Time-for-time, AMRAP, EMOM, Load/1RM, interval/hybrid types.
+- Each workout type requires explicit scoring unit rules (time/reps/weight/points).
 
----
+### Divisions and formats
+- Individual and team formats must be first-class.
+- Divisions (RX/Scaled/Masters/Adaptive) should be standardized templates with event-level overrides.
 
-## Risks and ambiguities
-1. **Schema ownership ambiguity:** no in-repo DB source of truth.
-2. **Authorization ambiguity:** absence of visible policy/versioning makes security posture hard to assess.
-3. **MVP boundary ambiguity:** product README lists broad capabilities that exceed implemented behavior.
-4. **Operational readiness ambiguity:** no tests/CI, so regression risk is high as scope grows.
-5. **Data scaling ambiguity:** current query/filter patterns may degrade with production dataset sizes.
+### Competition execution objects
+- Phases (qualifier/semifinal/final), heats, lanes need explicit progression model.
+- Cut rules must support elimination thresholds between phases.
+
+### Scoring and tie-breaks
+- Rank-based and points-based systems should both be representable.
+- Tie-break fields must be modeled per workout where applicable.
+- Leaderboard publication should distinguish provisional vs official states.
 
 ---
 
-## What should not be touched yet
-To keep momentum and avoid premature architecture churn:
-- Do **not** redesign routing architecture right now.
-- Do **not** introduce microservices or heavy abstraction layers.
-- Do **not** add Stripe/payment integration before core registration workflow is explicitly stabilized.
-- Do **not** implement scoring/leaderboard engine before schema and event-programming model are versioned.
-- Do **not** perform broad UI refactors before domain workflows and permissions are clarified.
+## Edge cases (realistic operational failures)
+
+### Registration edge cases
+- Pricing tier boundary race at cutoff time.
+- Category full between selection and submission.
+- Duplicate registration attempts by same athlete/team.
+- Role mismatch (athlete trying to register restricted category).
+
+### Competition-day edge cases
+- Judge submits score to wrong lane/athlete.
+- Late score correction after leaderboard already public.
+- Athlete no-show / withdrawal / disqualification.
+- Heat resequencing due to injury or timing drift.
+- Offline/unstable connectivity during score capture.
+
+### Governance edge cases
+- Unauthorized user accesses role-only data due to missing policy.
+- Conflicting score corrections from judge and head-judge/admin.
+- Incomplete audit trail for result disputes.
+
+---
+
+## Product/architecture guidance (do-not-touch-yet)
+- Do not redesign the app architecture before domain tables and constraints are stabilized.
+- Do not introduce Stripe before registration, pricing, and status transitions are reliable.
+- Do not build live leaderboard UX before score model + correction policy are explicit.
+- Do not optimize visuals before operational workflows (organizer/staff/judge) are executable.
+
+---
+
+## Biggest current risks
+1. No versioned DB schema/policies in repository.
+2. Missing explicit data model for divisions/categories/registrations as source-of-truth docs.
+3. Security/authorization confidence limited to UI checks in visible code.
+4. Competition execution domain (workouts/heats/scores/leaderboards) not yet encoded.
+5. No CI/test safety net for iterative delivery.

--- a/docs/worklist.md
+++ b/docs/worklist.md
@@ -1,211 +1,205 @@
-# CompCF Worklist (Baseline-driven)
+# CompCF Execution Worklist
 
-This worklist is intentionally pragmatic and based on what is verifiably present in the repository today.
+This worklist is ordered for implementation, not theme grouping. It prioritizes domain correctness before feature surface expansion.
 
 ---
 
-## MVP
+## MVP (true execution order)
 
-### 1) Establish database source of truth in-repo
-- **Why it matters:** current Supabase tables/views are referenced but not versioned in codebase; this blocks safe evolution.
-- **Module:** data platform / Supabase
+### 1) Version Supabase schema and policies in-repo
+- **Why it matters:** current domain cannot be safely evolved without a versioned DB source of truth.
+- **Module:** data platform
 - **Type:** database
 - **Priority:** P0
 - **Estimated complexity:** M
 - **Dependencies:** none
 - **Recommended implementation order:** 1
 
-### 2) Document and enforce auth/role model (profiles + access rules)
-- **Why it matters:** role-gated pages exist, but durable security requires explicit policy documentation and enforcement plan.
-- **Module:** auth & authorization
+### 2) Formalize role matrix (organizer/staff/judge/athlete/team captain/public)
+- **Why it matters:** permissions must be explicit before workflow implementation.
+- **Module:** auth + authorization
 - **Type:** backend
 - **Priority:** P0
-- **Estimated complexity:** M
+- **Estimated complexity:** S
 - **Dependencies:** item 1
 - **Recommended implementation order:** 2
 
-### 3) Implement registration creation flow (athlete -> event/category)
-- **Why it matters:** registrations are displayed but not created through a visible user flow in repo.
-- **Module:** registrations
-- **Type:** product
+### 3) Implement event divisions and categories source-of-truth
+- **Why it matters:** registration is invalid without reliable division/category structure.
+- **Module:** competition setup
+- **Type:** database
 - **Priority:** P0
 - **Estimated complexity:** M
 - **Dependencies:** items 1, 2
 - **Recommended implementation order:** 3
 
-### 4) Organizer event/category management hardening
-- **Why it matters:** organizer can create/publish events, but category/division management is missing for standardized publishing.
-- **Module:** organizer dashboard
-- **Type:** frontend
-- **Priority:** P0
-- **Estimated complexity:** M
-- **Dependencies:** items 1, 2
-- **Recommended implementation order:** 4
-
-### 5) Pricing tier CRUD and validation rules
-- **Why it matters:** public events read active pricing tiers; organizer-side maintenance is needed to make feature complete.
+### 4) Implement category pricing tier reliability (windows, priority, capacity hooks)
+- **Why it matters:** registration price and eligibility depend on correct tier logic.
 - **Module:** pricing
 - **Type:** backend
 - **Priority:** P0
 - **Estimated complexity:** M
-- **Dependencies:** items 1, 4
+- **Dependencies:** item 3
+- **Recommended implementation order:** 4
+
+### 5) Organizer setup workflow hardening (event -> division -> category -> pricing -> publish)
+- **Why it matters:** ensures published events are structurally valid before athletes register.
+- **Module:** organizer dashboard
+- **Type:** frontend
+- **Priority:** P0
+- **Estimated complexity:** M
+- **Dependencies:** items 3, 4
 - **Recommended implementation order:** 5
 
-### 6) Error handling and UX feedback pass on data writes
-- **Why it matters:** create/publish actions lack robust feedback/retry patterns, hurting reliability perception.
-- **Module:** shared UX patterns
+### 6) Build athlete registration creation flow with eligibility validation
+- **Why it matters:** core product value requires end-to-end registration, not only listing visibility.
+- **Module:** registrations
+- **Type:** product
+- **Priority:** P0
+- **Estimated complexity:** M
+- **Dependencies:** items 2, 3, 4, 5
+- **Recommended implementation order:** 6
+
+### 7) Registration lifecycle states and organizer visibility tooling
+- **Why it matters:** organizer needs actionable status management (pending/confirmed/cancelled/etc.).
+- **Module:** registrations
+- **Type:** backend
+- **Priority:** P1
+- **Estimated complexity:** M
+- **Dependencies:** item 6
+- **Recommended implementation order:** 7
+
+### 8) Baseline operational resilience (error UX + guardrails + logging hooks)
+- **Why it matters:** current write paths are optimistic and fragile under failure.
+- **Module:** shared app behavior
 - **Type:** frontend
 - **Priority:** P1
 - **Estimated complexity:** S
-- **Dependencies:** none
-- **Recommended implementation order:** 6
+- **Dependencies:** items 5, 6
+- **Recommended implementation order:** 8
 
-### 7) Add baseline automated checks (lint + smoke test workflow)
-- **Why it matters:** no CI means regressions are likely as multiple contributors iterate.
+### 9) CI baseline (lint + build + minimal smoke checks)
+- **Why it matters:** sustained iteration needs a regression gate.
 - **Module:** repo hygiene
 - **Type:** infra
 - **Priority:** P1
 - **Estimated complexity:** S
 - **Dependencies:** none
-- **Recommended implementation order:** 7
+- **Recommended implementation order:** 9
 
-### 8) Consolidate repository docs (single authoritative README + setup)
-- **Why it matters:** dual README files create confusion and onboarding friction.
-- **Module:** documentation
+### 10) Documentation consolidation for contributor onboarding
+- **Why it matters:** current duplicated README state slows contributors and increases misalignment.
+- **Module:** docs
 - **Type:** docs
 - **Priority:** P1
 - **Estimated complexity:** S
 - **Dependencies:** none
-- **Recommended implementation order:** 8
-
-### 9) Introduce typed Supabase schema bindings
-- **Why it matters:** reduces runtime query mismatch risk and improves developer velocity.
-- **Module:** data access
-- **Type:** backend
-- **Priority:** P1
-- **Estimated complexity:** S
-- **Dependencies:** item 1
-- **Recommended implementation order:** 9
-
-### 10) Add lightweight data-access boundary layer
-- **Why it matters:** direct queries in pages are fast for MVP but increase coupling and duplication.
-- **Module:** application architecture
-- **Type:** backend
-- **Priority:** P1
-- **Estimated complexity:** M
-- **Dependencies:** items 1, 9
 - **Recommended implementation order:** 10
 
 ---
 
 ## Post-MVP
 
-### 11) Qualification workflow foundation
-- **Why it matters:** explicitly part of product trajectory after core publication/registration.
-- **Module:** qualification
-- **Type:** product
-- **Priority:** P1
-- **Estimated complexity:** L
-- **Dependencies:** items 1, 2, 3, 4
-- **Recommended implementation order:** 11
-
-### 12) Competition programming model (WOD definitions + standards)
-- **Why it matters:** prerequisite for scoring and schedule coherence.
-- **Module:** event programming
+### 11) Workout model and standards (WOD types, units, tie-break fields)
+- **Why it matters:** scoring requires canonical workout definition.
+- **Module:** competition programming
 - **Type:** backend
 - **Priority:** P1
 - **Estimated complexity:** L
-- **Dependencies:** items 1, 4
-- **Recommended implementation order:** 12
+- **Dependencies:** items 1, 3
+- **Recommended implementation order:** 11
 
-### 13) Schedule/heats/lanes management
-- **Why it matters:** core operational feature for event-day execution.
+### 12) Phases, heats, lanes, and assignment workflow
+- **Why it matters:** competition-day operations require structured progression.
 - **Module:** operations
 - **Type:** product
 - **Priority:** P1
 - **Estimated complexity:** L
-- **Dependencies:** items 1, 12
-- **Recommended implementation order:** 13
+- **Dependencies:** item 11
+- **Recommended implementation order:** 12
 
-### 14) Judge workflows for score input and correction
-- **Why it matters:** enables controlled, accountable score capture.
+### 13) Judge workflow (assignment, score entry, correction request)
+- **Why it matters:** score capture must be role-based and auditable.
 - **Module:** judge tooling
 - **Type:** frontend
 - **Priority:** P1
 - **Estimated complexity:** L
-- **Dependencies:** items 2, 12, 13
-- **Recommended implementation order:** 14
+- **Dependencies:** items 2, 11, 12
+- **Recommended implementation order:** 13
 
-### 15) Live leaderboard pipeline and publication
-- **Why it matters:** key product value for spectators and athletes.
-- **Module:** scoring/leaderboard
+### 14) Scoring engine and leaderboard derivation
+- **Why it matters:** core CompCF outcome is reliable rankings.
+- **Module:** scoring + leaderboard
 - **Type:** backend
 - **Priority:** P1
 - **Estimated complexity:** L
-- **Dependencies:** items 12, 14
+- **Dependencies:** items 11, 13
+- **Recommended implementation order:** 14
+
+### 15) Qualification and cut rules across phases
+- **Why it matters:** many CrossFit events depend on phase progression and eliminations.
+- **Module:** competition rules
+- **Type:** product
+- **Priority:** P1
+- **Estimated complexity:** L
+- **Dependencies:** items 11, 12, 14
 - **Recommended implementation order:** 15
 
-### 16) Audit trail/version history for score updates
-- **Why it matters:** essential for trust and dispute resolution.
+### 16) Score governance and dispute/audit tooling
+- **Why it matters:** official results need traceable correction history.
 - **Module:** governance
 - **Type:** database
 - **Priority:** P1
 - **Estimated complexity:** M
-- **Dependencies:** items 1, 14
+- **Dependencies:** items 13, 14
 - **Recommended implementation order:** 16
 
 ---
 
-## Out of scope (this phase)
+## Out of scope (this pass)
 
-### 17) Payment processing integration (Stripe)
-- **Why it matters:** monetization and paid registrations are important, but intentionally deferred.
+### 17) Stripe/payment integration
+- **Why it matters:** important but intentionally deferred until registration model is stable.
 - **Module:** payments
 - **Type:** backend
 - **Priority:** P2
 - **Estimated complexity:** L
-- **Dependencies:** item 3 stabilization + pricing rules clarity
+- **Dependencies:** items 4, 6, 7 stabilized
 - **Recommended implementation order:** 17
 
-### 18) Major visual redesign
-- **Why it matters:** current UI is coherent enough for functional MVP iteration.
-- **Module:** design system
+### 18) Major UI redesign
+- **Why it matters:** functional domain completion is higher value than visual redesign now.
+- **Module:** design
 - **Type:** frontend
 - **Priority:** P2
 - **Estimated complexity:** L
-- **Dependencies:** product workflow stabilization
+- **Dependencies:** MVP workflow completion
 - **Recommended implementation order:** 18
 
-### 19) Large architectural rewrite (service decomposition)
-- **Why it matters:** premature for current scope/size and would slow delivery.
+### 19) Large architecture rewrite
+- **Why it matters:** premature before real scale constraints are observed.
 - **Module:** architecture
 - **Type:** backend
 - **Priority:** P2
 - **Estimated complexity:** L
-- **Dependencies:** proven scale constraints
+- **Dependencies:** production usage evidence
 - **Recommended implementation order:** 19
 
 ---
 
 ## Next 5 best tasks
-1. Establish DB schema/migrations and policy baseline in-repo (Item 1).
-2. Document + enforce auth/role model tied to DB policies (Item 2).
-3. Implement athlete registration creation flow end-to-end (Item 3).
-4. Add organizer category/division management to support standardization (Item 4).
-5. Implement pricing tier management + constraints (Item 5).
+1. Version Supabase schema + policies in-repo.
+2. Formalize and enforce complete role matrix.
+3. Make divisions/categories canonical and constrained.
+4. Harden pricing tier semantics.
+5. Implement organizer setup flow validation before publish.
 
 ---
 
 ## Safe first implementation candidate for Codex
-**Candidate:** Item 8 — Consolidate repository docs (single authoritative README + setup).
+**Candidate:** Task 2 — formalize role matrix in docs + policy checklist.
 
-**Why safe first:**
-- documentation-only
-- zero production behavior change
-- reduces contributor confusion immediately
-- low coupling with uncertain schema/auth decisions
-
-**Suggested small deliverable:**
-- keep one canonical README
-- add setup/env section for Supabase public vars
-- add explicit current capability matrix (implemented vs planned)
+**Why this is safe and high leverage:**
+- no runtime behavior change required initially
+- unblocks predictable permission design for all upcoming modules
+- reduces rework risk in organizer, registration, and judge features


### PR DESCRIPTION
## Summary
- Hardened `docs/repository-baseline-audit.md` with explicit CompCF role modeling, concrete domain workflows, a dedicated data model section, CrossFit-specific business requirements, and operational edge cases.
- Restructured `docs/worklist.md` into true execution order for MVP and post-MVP, ensuring category/division + pricing reliability precedes registration flow.
- Kept documentation implementation-oriented and runtime-neutral (documentation-only).

## Top priorities
1. Version Supabase schema + policies in-repo.
2. Formalize and enforce full role matrix.
3. Canonicalize divisions/categories.
4. Harden pricing tier semantics.
5. Validate organizer setup flow before event publication.

## Remaining unknowns
- Canonical DB schema/policy design decisions (currently not in repo as code).
- Final MVP acceptance boundaries for staff/judge/team captain scope.
- Score governance and dispute policy details required before leaderboard finalization.
