### PR TITLE
docs: add github project and backlog foundation

### DIFF
--- a/docs/product/backlog-seed.md
+++ b/docs/product/backlog-seed.md
@@ -1,0 +1,125 @@
+# CompCF Backlog Seed
+
+Legend: `Type | Epic | Domain | Persona | Phase | Priority | Size`
+
+## Top 12 MVP Stories
+1. **Version Supabase schema and policies in-repo**  
+   `Story | Identity & Roles | Infrastructure | Admin | MVP | P0 | M`  
+   Story: As an admin, I need schema/policy versioning in repo so access rules are traceable.  
+   AC summary: migration baseline committed; policy diff review pattern documented; rollback notes included.  
+   Dependencies: none.
+2. **Formalize role matrix and enforcement baseline**  
+   `Story | Identity & Roles | Identity & Roles | Admin | MVP | P0 | M`  
+   Story: As admin, I need a canonical role matrix so permissions are predictable.  
+   AC: matrix documented; route/action mapping defined; deny-by-default gaps listed.  
+   Dependencies: #1.
+3. **Canonical divisions/categories source of truth**  
+   `Story | Divisions / Categories / Pricing | Divisions / Categories / Pricing | Organizer | MVP | P0 | S`  
+   Story: As organizer, I need one canonical taxonomy to avoid invalid registrations.  
+   AC: single source table/file; allowed combinations documented; validation examples present.  
+   Dependencies: Event Publication baseline.
+4. **Pricing tier reliability baseline**  
+   `Story | Divisions / Categories / Pricing | Divisions / Categories / Pricing | Organizer | MVP | P0 | M`  
+   Story: As organizer, I need predictable tier behavior so checkout totals are trusted.  
+   AC: tier model documented; transition rules clear; test matrix listed.  
+   Dependencies: #3.
+5. **Organizer setup flow hardening**  
+   `Story | Organizer Management | Organizer Management | Organizer | MVP | P0 | M`  
+   Story: As organizer, I want setup to complete without manual admin fixes.  
+   AC: setup steps defined; required fields identified; error states and recovery paths listed.  
+   Dependencies: #2.
+6. **Athlete registration creation flow**  
+   `Story | Registration | Registration | Individual Athlete | MVP | P0 | M`  
+   Story: As athlete, I need a clear registration flow to successfully enter an event.  
+   AC: minimal path mapped; success/failure states captured; required profile checks listed.  
+   Dependencies: #3, #4.
+7. **Registration lifecycle states**  
+   `Story | Registration | Registration | Staff | MVP | P0 | S`  
+   Story: As staff, I need consistent lifecycle states so support actions are deterministic.  
+   AC: states defined; transition rules documented; invalid transitions blocked in spec.  
+   Dependencies: #6.
+8. **Organizer registration visibility**  
+   `Story | Registration | Organizer Management | Organizer | MVP | P1 | S`  
+   Story: As organizer, I need registration visibility to manage readiness and capacity.  
+   AC: required views listed; key filters defined; minimum audit columns documented.  
+   Dependencies: #6, #7.
+9. **Baseline operational resilience**  
+   `Story | Admin / Audit / Governance | Infrastructure | Admin | MVP | P1 | M`  
+   Story: As admin, I need failure-mode baselines so event-day ops remain stable.  
+   AC: risk checklist defined; backup/recovery expectations documented; incident severity rubric set.  
+   Dependencies: #1.
+10. **CI baseline for quality gates**  
+   `Story | Admin / Audit / Governance | Infrastructure | Staff | MVP | P1 | S`  
+   Story: As contributor, I need CI checks so regressions are caught before merge.  
+   AC: minimum checks listed; branch protection assumptions documented; failure triage owner defined.  
+   Dependencies: none.
+11. **Docs consolidation for product + delivery**  
+   `Story | Public Experience | Documentation | Staff | MVP | P1 | S`  
+   Story: As team member, I need centralized docs so execution decisions are aligned.  
+   AC: product docs index exists; stale docs marked; contribution conventions added.  
+   Dependencies: none.
+12. **Project setup and contributor onboarding**  
+   `Story | Organizer Management | Documentation | Volunteer | MVP | P1 | S`  
+   Story: As new contributor, I need onboarding steps to start executing backlog items quickly.  
+   AC: local setup steps; issue-to-PR conventions; first-task guidance defined.  
+   Dependencies: #10.
+
+## Top 12 Volunteer-Domain Stories
+1. **Volunteer application intake form + storage**  
+   `Story | Volunteer Recruitment | Volunteer Recruitment | Volunteer | MVP | P0 | M`  
+   AC: required fields defined; submission state tracked; organizer visibility baseline.  
+   Dependencies: Identity baseline.
+2. **Volunteer profile: skills and availability**  
+   `Story | Volunteer Recruitment | Volunteer Recruitment | Volunteer | MVP | P0 | M`  
+   AC: skills taxonomy defined; availability slots captured; update rules documented.  
+   Dependencies: #1.
+3. **Organizer volunteer review workflow**  
+   `Story | Volunteer Recruitment | Volunteer Recruitment | Organizer | MVP | P0 | S`  
+   AC: review queue states; reviewer notes field; decision timestamps.  
+   Dependencies: #1.
+4. **Volunteer status pipeline (applied/accepted/rejected/assigned)**  
+   `Story | Volunteer Onboarding | Volunteer Onboarding | Staff | MVP | P0 | S`  
+   AC: canonical statuses; transition ownership; audit expectation.  
+   Dependencies: #3.
+5. **Role-based volunteer assignment baseline**  
+   `Story | Volunteer Scheduling & Assignments | Volunteer Scheduling | Organizer | MVP | P0 | M`  
+   AC: role-to-skill mapping; assignment constraints; conflict handling notes.  
+   Dependencies: #2, #4.
+6. **Shift creation for volunteer operations**  
+   `Story | Volunteer Scheduling & Assignments | Volunteer Scheduling | Staff | MVP | P0 | S`  
+   AC: shift schema; time/location fields; coverage target definition.  
+   Dependencies: #4.
+7. **Judging assignment model for volunteer judges**  
+   `Story | Judging Live | Judging Live | Judge | MVP | P0 | M`  
+   AC: assignment unit defined; judge eligibility rules; handoff protocol.  
+   Dependencies: #5, #6.
+8. **Care shift assignment workflow**  
+   `Story | Care Operations | Care Operations | Volunteer | MVP | P1 | S`  
+   AC: care role definitions; escalation owner; fill-rate target.  
+   Dependencies: #5, #6.
+9. **Build shift assignment workflow**  
+   `Story | Build / Logistics Operations | Build / Logistics | Volunteer | MVP | P1 | S`  
+   AC: setup/teardown shift types; required capability tags; completion flag.  
+   Dependencies: #5, #6.
+10. **Volunteer communication and instructions baseline**  
+   `Story | Volunteer Onboarding | Volunteer Onboarding | Volunteer | MVP | P1 | S`  
+   AC: instruction template; pre-shift reminder timing; owner by shift.  
+   Dependencies: #4.
+11. **Volunteer replacement workflow**  
+   `Story | Volunteer Scheduling & Assignments | Volunteer Scheduling | Staff | MVP | P1 | M`  
+   AC: replacement trigger states; replacement candidate shortlist; audit notes.  
+   Dependencies: #5, #6.
+12. **Volunteer roster visibility by role and shift**  
+   `Story | Volunteer Scheduling & Assignments | Volunteer Scheduling | Organizer | MVP | P1 | S`  
+   AC: roster filters; assignment status columns; unfilled-role alerts.  
+   Dependencies: #5, #6.
+
+## 8 Post-MVP Stories
+1. Qualification submission and review pipeline (`Registration`, `Post-MVP`, `P1`, `L`).
+2. Programming builder for WOD definitions (`Competition Programming`, `Post-MVP`, `P1`, `L`).
+3. Heat/lane auto-generation with manual override (`Scheduling / Heats`, `Post-MVP`, `P1`, `L`).
+4. Live scoring calculation engine (`Scoring & Leaderboard`, `Post-MVP`, `P0`, `XL`).
+5. Public live leaderboard experience (`Public Experience`, `Post-MVP`, `P1`, `L`).
+6. Judge offline capture and sync strategy (`Judging Live`, `Post-MVP`, `P1`, `L`).
+7. Volunteer certification and repeat-preference profile (`Volunteer Onboarding`, `Post-MVP`, `P2`, `M`).
+8. Admin governance automation and risk rules (`Admin / Audit / Governance`, `Post-MVP`, `P1`, `M`).

--- a/docs/product/epics.md
+++ b/docs/product/epics.md
@@ -1,0 +1,161 @@
+# CompCF Epic Catalog
+
+## 1) Identity & Roles
+- **Scope:** authentication, role matrix, permission enforcement baseline.
+- **Why it matters:** all execution reliability depends on clean access boundaries.
+- **MVP scope:** explicit role matrix + baseline server/client guardrails.
+- **Post-MVP scope:** delegated permission sets and policy automation.
+- **Out of scope:** SSO enterprise integrations.
+- **Main personas:** Admin, Organizer, Staff, Judge.
+- **Dependencies:** Admin / Audit / Governance.
+- **Success signal:** role-based access defects trend toward zero.
+
+## 2) Organizer Management
+- **Scope:** organizer profile, ownership and event-level control.
+- **Why it matters:** core customer type is competition organizer.
+- **MVP scope:** stable organizer setup flow.
+- **Post-MVP scope:** multi-org controls and delegated admin.
+- **Out of scope:** invoicing/CRM.
+- **Main personas:** Organizer, Admin.
+- **Dependencies:** Identity & Roles.
+- **Success signal:** organizer setup completed without manual intervention.
+
+## 3) Event Publication
+- **Scope:** event creation, publication states, public visibility baseline.
+- **Why it matters:** event visibility is top-of-funnel for registrations.
+- **MVP scope:** draft/published flow + public listing metadata.
+- **Post-MVP scope:** richer media + announcement tools.
+- **Out of scope:** sponsorship marketplace.
+- **Main personas:** Organizer, Public User.
+- **Dependencies:** Organizer Management.
+- **Success signal:** organizers can publish events with complete mandatory metadata.
+
+## 4) Divisions / Categories / Pricing
+- **Scope:** canonical taxonomy, constraints, pricing tiers.
+- **Why it matters:** registration accuracy and fairness depend on this model.
+- **MVP scope:** source-of-truth divisions/categories + reliable tier selection.
+- **Post-MVP scope:** dynamic policies and rule packs.
+- **Out of scope:** country-specific tax logic.
+- **Main personas:** Organizer, Individual Athlete, Team Captain.
+- **Dependencies:** Event Publication.
+- **Success signal:** fewer registration corrections caused by category mismatch.
+
+## 5) Registration
+- **Scope:** registration creation + lifecycle state handling.
+- **Why it matters:** primary revenue and participant conversion path.
+- **MVP scope:** individual/team registration flow + state transitions.
+- **Post-MVP scope:** qualification-linked enrollment and waitlist automation.
+- **Out of scope:** payment-provider expansion.
+- **Main personas:** Individual Athlete, Team Captain, Organizer, Staff.
+- **Dependencies:** Divisions / Categories / Pricing.
+- **Success signal:** higher successful registration completion ratio.
+
+## 6) Volunteer Recruitment
+- **Scope:** application intake and candidate discovery.
+- **Why it matters:** event day quality depends on volunteer throughput.
+- **MVP scope:** intake form + organizer review queue.
+- **Post-MVP scope:** campaign/re-engagement workflows.
+- **Out of scope:** external applicant tracking integrations.
+- **Main personas:** Volunteer, Organizer.
+- **Dependencies:** Public Experience.
+- **Success signal:** time-to-first-response for applications decreases.
+
+## 7) Volunteer Onboarding
+- **Scope:** qualification, status movement, communication baseline.
+- **Why it matters:** recruited volunteers must become operation-ready.
+- **MVP scope:** status pipeline + instruction delivery.
+- **Post-MVP scope:** onboarding checklists/certification tracking.
+- **Out of scope:** LMS implementation.
+- **Main personas:** Volunteer, Organizer, Staff.
+- **Dependencies:** Volunteer Recruitment.
+- **Success signal:** accepted volunteers show up assignment-ready.
+
+## 8) Volunteer Scheduling & Assignments
+- **Scope:** shifts, role assignment, replacement handling.
+- **Why it matters:** live operations fail without role coverage.
+- **MVP scope:** shift creation + assignment matrix + replacements.
+- **Post-MVP scope:** optimization/auto-scheduling.
+- **Out of scope:** payroll.
+- **Main personas:** Organizer, Staff, Volunteer, Judge.
+- **Dependencies:** Volunteer Onboarding.
+- **Success signal:** fewer uncovered shifts on competition day.
+
+## 9) Judging Live
+- **Scope:** judging assignment and live capture workflow.
+- **Why it matters:** scoring credibility requires strong judging operations.
+- **MVP scope:** judge assignment model + decision capture baseline.
+- **Post-MVP scope:** offline mode + validation escalations.
+- **Out of scope:** computer vision judging.
+- **Main personas:** Judge, Staff, Organizer.
+- **Dependencies:** Volunteer Scheduling & Assignments, Scoring & Leaderboard.
+- **Success signal:** reduced score submission latency and disputes.
+
+## 10) Care Operations
+- **Scope:** athlete care/support shift operations.
+- **Why it matters:** athlete experience and safety.
+- **MVP scope:** care shift definitions + staffing visibility.
+- **Post-MVP scope:** incident capture and post-event reporting.
+- **Out of scope:** medical records.
+- **Main personas:** Volunteer, Staff, Organizer.
+- **Dependencies:** Volunteer Scheduling & Assignments.
+- **Success signal:** care stations maintain required coverage.
+
+## 11) Build / Logistics Operations
+- **Scope:** setup/teardown and logistics staffing.
+- **Why it matters:** venue readiness and transition speed.
+- **MVP scope:** build shift assignment and checklist visibility.
+- **Post-MVP scope:** asset tracking and logistics analytics.
+- **Out of scope:** procurement system.
+- **Main personas:** Volunteer, Staff, Organizer.
+- **Dependencies:** Volunteer Scheduling & Assignments.
+- **Success signal:** setup milestones met on schedule.
+
+## 12) Competition Programming
+- **Scope:** WOD/programming management.
+- **Why it matters:** competition format quality and fairness.
+- **MVP scope:** capture planned placeholder structure.
+- **Post-MVP scope:** full workout definition and validation tools.
+- **Out of scope:** AI workout generation.
+- **Main personas:** Organizer, Staff.
+- **Dependencies:** Divisions / Categories / Pricing.
+- **Success signal:** published programming aligned to division constraints.
+
+## 13) Scheduling / Heats
+- **Scope:** heat planning and timing operations.
+- **Why it matters:** day-of flow and judge/volunteer coordination.
+- **MVP scope:** roadmap placeholder and dependency mapping.
+- **Post-MVP scope:** heat generation and lane assignment workflows.
+- **Out of scope:** hardware timing integration.
+- **Main personas:** Organizer, Staff, Judge.
+- **Dependencies:** Registration, Competition Programming.
+- **Success signal:** on-time heat operations with minimal manual reshuffling.
+
+## 14) Scoring & Leaderboard
+- **Scope:** scoring engine and leaderboard presentation.
+- **Why it matters:** central value proposition for CrossFit competitions.
+- **MVP scope:** backlog foundation and quality constraints.
+- **Post-MVP scope:** full live scoring computation and rankings.
+- **Out of scope:** historical predictive analytics.
+- **Main personas:** Judge, Organizer, Public User, Athlete.
+- **Dependencies:** Judging Live.
+- **Success signal:** trusted, timely leaderboard updates.
+
+## 15) Public Experience
+- **Scope:** public event and results consumption.
+- **Why it matters:** supports audience growth and participant confidence.
+- **MVP scope:** event listing/read-only details baseline.
+- **Post-MVP scope:** richer live experience and subscriptions.
+- **Out of scope:** social media network features.
+- **Main personas:** Public User, Individual Athlete.
+- **Dependencies:** Event Publication.
+- **Success signal:** increased public event page engagement.
+
+## 16) Admin / Audit / Governance
+- **Scope:** auditability, controls, and governance operations.
+- **Why it matters:** platform trust for organizers and participants.
+- **MVP scope:** baseline audit trail and governance policy docs.
+- **Post-MVP scope:** advanced moderation/risk workflows.
+- **Out of scope:** legal case management.
+- **Main personas:** Admin.
+- **Dependencies:** Identity & Roles.
+- **Success signal:** critical changes are attributable and reviewable.

--- a/docs/product/github-project-model.md
+++ b/docs/product/github-project-model.md
@@ -1,0 +1,70 @@
+# CompCF GitHub Project Model
+
+## Purpose
+GitHub is the single operational surface for product planning and execution at CompCF:
+- planning in Issues + Project fields
+- delivery in PR-linked issues
+- roadmap in date-based project views
+
+Primary project target: **CompCF Product & Delivery**.
+
+## Custom fields (target model)
+- Status: Backlog, Ready, In Progress, In Review, Blocked, Done
+- Type: Epic, Story, Task, Bug, Spike
+- Domain: Identity & Roles, Organizer Management, Event Publication, Divisions / Categories / Pricing, Registration, Volunteer Recruitment, Volunteer Onboarding, Volunteer Scheduling, Judging Live, Care Operations, Build / Logistics, Competition Programming, Scheduling / Heats, Scoring & Leaderboard, Public Experience, Admin / Audit / Governance, Documentation, Infrastructure
+- Persona: Organizer, Staff, Judge, Individual Athlete, Team Captain, Volunteer, Public User, Admin
+- Phase: MVP, Post-MVP, Later
+- Priority: P0, P1, P2
+- Size: XS, S, M, L, XL
+- Risk: Low, Medium, High
+- Sprint: Sprint 0-3 (or iteration field where supported)
+- Start Date (date)
+- Target Date (date)
+- Parent issue + Sub-issue progress (when supported)
+
+## Status conventions
+- **Backlog:** not yet groomed
+- **Ready:** groomed with acceptance criteria and dependencies
+- **In Progress:** active implementation
+- **In Review:** open PR or review pending
+- **Blocked:** external dependency or unresolved decision
+- **Done:** merged and validated
+
+## View conventions
+- **Master Backlog (Table):** full triage and sorting
+- **Delivery Board (Board by Status):** execution flow
+- **MVP by Domain (Board):** focus MVP work by domain
+- **Roadmap (Roadmap):** Start Date to Target Date planning
+- **Volunteer Domain (Table):** volunteer-specific workstream
+- **Epics (Table):** only Type=Epic for decomposition checks
+- **Current Sprint (Table):** active sprint and not done
+
+## Item type conventions
+- **Epic:** value stream slice, decomposed into stories/tasks.
+- **Story:** persona-driven deliverable with clear acceptance criteria.
+- **Task:** implementation/ops work with no direct persona outcome.
+- **Bug:** defect in expected behavior.
+- **Spike:** time-boxed investigation reducing uncertainty.
+
+## PR linkage rules
+- Every PR references issue(s) in body using `Closes #<issue>` or `Refs #<issue>`.
+- If work is partial, use `Refs` and keep issue open.
+- If done, use `Closes` for automatic issue closure.
+
+## Sub-issue conventions
+- Use Epic issue as parent.
+- Create Story issues as children.
+- If GitHub sub-issue feature is unavailable, include a child checklist in parent issue body and a `Parent Epic: #id` line in child issues.
+
+## Dependency conventions
+Use issue dependencies only when sequencing materially impacts delivery clarity:
+- hard technical prerequisites
+- policy/governance blockers
+- shared domain model dependencies
+
+## Codex work selection heuristic
+1. Pick **Ready + P0/P1 + MVP** first.
+2. Prefer items with no unresolved dependencies.
+3. In ties, choose smaller item size first (XS/S/M).
+4. Keep one active item per domain unless explicit parallelization is needed.
+5. Ensure PR links issue and updates project status.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -1,0 +1,65 @@
+# CompCF Personas
+
+## Organizer
+- **Purpose:** Own competition setup and delivery from publication to results.
+- **Core goals:** launch events fast, keep registrations accurate, run fair competition day.
+- **MVP permissions:** create/manage organization, events, divisions, pricing, registration windows, staff access, basic score correction visibility.
+- **Post-MVP permissions:** qualification funnels, advanced programming, automation rules, payout/report exports.
+- **Frustrations / pain points:** fragmented tools, late athlete changes, unclear volunteer readiness.
+- **Key workflows touched:** organizer setup, event publication, registration oversight, volunteer assignment review.
+
+## Staff
+- **Purpose:** Assist organizers with operational execution.
+- **Core goals:** keep heats on-time, reduce check-in and desk bottlenecks.
+- **MVP permissions:** view assigned events, update operational states, manage check-in/support tasks.
+- **Post-MVP permissions:** delegated module ownership, richer analytics dashboards.
+- **Frustrations / pain points:** poor handoff clarity, missing real-time status visibility.
+- **Key workflows touched:** registration support, schedule operations, care/build coordination.
+
+## Judge
+- **Purpose:** Capture and validate performance outcomes per assignment.
+- **Core goals:** accurate score entry, clear assignment context.
+- **MVP permissions:** view assigned heats/lists, submit score decisions, mark exceptions.
+- **Post-MVP permissions:** offline-first judging, validation workflows, dispute handling queue.
+- **Frustrations / pain points:** assignment ambiguity, last-minute athlete switches.
+- **Key workflows touched:** judging assignment, live score capture, correction handoff.
+
+## Individual Athlete
+- **Purpose:** Register and compete as an individual.
+- **Core goals:** frictionless signup, transparent pricing/rules, clear event communications.
+- **MVP permissions:** account/profile, event discovery, registration and status tracking.
+- **Post-MVP permissions:** qualification submissions, personal progression history.
+- **Frustrations / pain points:** confusing categories/divisions, uncertain registration status.
+- **Key workflows touched:** event browse, registration lifecycle, public leaderboard checks.
+
+## Team Captain
+- **Purpose:** Manage team roster and team registration.
+- **Core goals:** complete team signup without admin back-and-forth.
+- **MVP permissions:** create team, invite/manage members, submit team registration.
+- **Post-MVP permissions:** team qualification assets, lineup changes with rule validation.
+- **Frustrations / pain points:** roster lock confusion, missing member confirmation status.
+- **Key workflows touched:** division selection, registration completion, captain communications.
+
+## Volunteer
+- **Purpose:** Support event operations through scheduled roles.
+- **Core goals:** apply quickly, understand assignment and expectations.
+- **MVP permissions:** submit application/profile/availability, receive status and assignments.
+- **Post-MVP permissions:** preferred roles, repeat-volunteer profile, certifications.
+- **Frustrations / pain points:** slow feedback loops, unclear shift instructions.
+- **Key workflows touched:** volunteer intake, onboarding, assignment and replacements.
+
+## Public User
+- **Purpose:** Follow competitions without logging in.
+- **Core goals:** discover events and follow results easily.
+- **MVP permissions:** public event listing and detail pages.
+- **Post-MVP permissions:** live heat tracking, notifications, richer media embeds.
+- **Frustrations / pain points:** stale event info, hard-to-read standings.
+- **Key workflows touched:** public browsing, schedule/results consumption.
+
+## Admin
+- **Purpose:** Protect platform integrity, governance, and support escalations.
+- **Core goals:** enforce policy consistency, audit critical actions.
+- **MVP permissions:** role override tooling, audit log visibility, organization moderation.
+- **Post-MVP permissions:** full governance workflows, risk controls, policy automation.
+- **Frustrations / pain points:** weak traceability, inconsistent permissions baseline.
+- **Key workflows touched:** role governance, audit review, incident handling.

--- a/docs/product/user-story-template.md
+++ b/docs/product/user-story-template.md
@@ -1,0 +1,41 @@
+# CompCF User Story Template
+
+## Story statement
+As a **{persona}**, I want **{goal}** so that **{outcome}**.
+
+## Context
+- Business context:
+- Current pain/problem:
+- Related epic/domain:
+
+## Acceptance criteria
+- [ ] AC1:
+- [ ] AC2:
+- [ ] AC3:
+
+## Data impacts
+- New entities/fields:
+- Data constraints:
+- Migration or seed implications:
+
+## Permissions impacts
+- Roles affected:
+- Access control changes:
+- Auditability requirements:
+
+## Edge cases
+- Edge case 1:
+- Edge case 2:
+
+## Non-goals
+- Explicitly out of scope:
+
+## Implementation notes
+- Suggested sequence:
+- Dependencies:
+- Observability/logging:
+
+## Test notes
+- Unit/integration focus:
+- Manual verification path:
+- Regression risks:


### PR DESCRIPTION
Adds GitHub-native backlog model docs and seeds repository issues/labels for CompCF delivery.

Also documents remaining manual steps for Projects v2 due missing project scopes in current token.