### PR TITLE
fix: restore athlete profile save by syncing profile schema

### DIFF
--- a/supabase/migrations/20260409000100_profile_schema_reconciliation.sql
+++ b/supabase/migrations/20260409000100_profile_schema_reconciliation.sql
@@ -1,0 +1,17 @@
+-- Reconcile live profile schema drift for athlete profile save.
+-- Ensures athlete profile baseline fields exist in environments that missed earlier migration(s).
+
+alter table public.profiles
+  add column if not exists date_of_birth date;
+
+alter table public.profiles
+  add column if not exists affiliate text;
+
+alter table public.profiles
+  add column if not exists city text;
+
+alter table public.profiles
+  add column if not exists country text;
+
+-- Ensure PostgREST sees the updated columns immediately in live environments.
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- add a schema reconciliation migration to ensure athlete profile baseline columns exist on `public.profiles` in drifted environments
- explicitly ensure `date_of_birth`, `affiliate`, `city`, and `country` are present with `add column if not exists`
- notify PostgREST to reload schema cache after reconciliation

## Root cause
Production DB schema drift: frontend save writes `profiles.affiliate`, but deployed schema cache/database did not expose that column.

## Scope
- schema-only fix (no athlete UI redesign, no country/box feature removal)

## Validation
- npm ci
- npm run lint
- npx tsc --noEmit
- npm run build (blocked in this environment by external Google Fonts/Turbopack fetch issue, unrelated)