### PR TITLE
fix: sync live supabase schema for athlete profile

### DIFF
--- a/docs/database-baseline.md
+++ b/docs/database-baseline.md
@@ -99,6 +99,20 @@ Because current runtime authenticates from client-side Supabase auth, policies a
 - `profiles` includes minimal athlete onboarding fields for registration readiness: `first_name`, `last_name`, `date_of_birth`, `affiliate`, `city`, `country`, `profile_photo_url`.
 - This is intentionally a minimal MVP profile baseline (no social/community profile expansion).
 
+## Live migration application note (critical)
+- Merging a SQL migration file into Git **does not** update the live Supabase database by itself.
+- For production/staging reliability, migrations must be explicitly applied to the exact Supabase project used by the deployed app.
+- Recommended operator workflow:
+  1. Confirm deployment environment variables (`NEXT_PUBLIC_SUPABASE_URL`) and the intended Supabase project ref match.
+  2. From a linked Supabase CLI context, run:
+     - `supabase migration list`
+     - `supabase db push`
+     - `supabase db diff --linked` (should be empty after sync)
+  3. Verify required profile columns directly:
+     - `select column_name from information_schema.columns where table_schema = 'public' and table_name = 'profiles' and column_name in ('date_of_birth','affiliate','city','country','profile_photo_url') order by column_name;`
+  4. If schema cache lag is suspected, force PostgREST schema refresh:
+     - `select pg_notify('pgrst', 'reload schema');`
+
 ## Registration pricing-tier traceability baseline
 - `registrations` now stores the canonical `pricing_tier_id` selected at creation time.
 - Registration creation logic resolves the currently valid active tier server-side and persists that foreign key.


### PR DESCRIPTION
## Summary
- audit production deployment ref against `origin/main` and confirm latest merged schema-sync commit is in production code
- document a minimal explicit live migration runbook in `docs/database-baseline.md`
- include exact verification SQL for `public.profiles` athlete columns and PostgREST schema refresh

## Root cause
Migration SQL merged in Git without guaranteed live DB application workflow can leave runtime schema drift.

## Scope
- no athlete UX redesign
- no runtime feature changes
- process hardening + operational clarity

## Validation
- GitHub deployment ref check
- origin/main head check
- npm run lint